### PR TITLE
Added color parsing support

### DIFF
--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -36,9 +36,8 @@ class TestParse(object):
         vs = ViewState(raw=b'\xff\x01\x10\x67\x68\x67')
         assert vs.decode() == (True, False, True)
 
-    @pytest.mark.skip(reason='Color parsing is not yet supported')
     def test_color(self):
-        vs = ViewState(raw=b'\xff\x01\n\x91\x01')
+        vs = ViewState(raw=b'\xff\x01\n\x91')
         assert vs.decode() == 'Color: Salmon'
 
     def test_rgba(self):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -39,6 +39,9 @@ class TestParse(object):
     def test_color(self):
         vs = ViewState(raw=b'\xff\x01\n\x91')
         assert vs.decode() == 'Color: Salmon'
+        
+        vs = ViewState(raw=b'\xff\x01\n\x8d\x01')
+        assert vs.decode() == 'Color: Red'
 
     def test_rgba(self):
         vs = ViewState(raw=b'\xff\x01\x09\x10\x20\x30\x40')

--- a/viewstate/parse.py
+++ b/viewstate/parse.py
@@ -41,6 +41,15 @@ class Const(Parser):
         return cls.const, remain
 
 
+class Noop(Parser):
+    # This class is not up to specification. No value should be added to the parsed tree.
+    marker = 0x01
+
+    @staticmethod
+    def parse(b):
+        return None, b
+
+
 class NoneConst(Const):
     marker = 0x64
     const = None
@@ -111,10 +120,200 @@ class Color(Parser):
 
     @staticmethod
     def parse(b):
-        # No specification for color parsing, we're assuming it's just two bytes
-        # One example we have is that `\n\x91\x01` is parsed as `Color: Color [Salmon]`
+        # No specification for color parsing
+        # The first example we had was that `\n\x91\x01` is parsed as `Color: Color [Salmon]`
         # Originally reported in https://github.com/yuvadm/viewstate/issues/2
-        return 'Color: unknown', b[2:]
+
+        # Then, it was found that colors can also be encoded with only one byte
+        # For example, `\n\x5b` is parsed as `Color: Color [LightBlue]`
+        # Moreover, if we check this page: https://docs.microsoft.com/en-us/dotnet/api/system.drawing.knowncolor?redirectedfrom=MSDN&view=netframework-4.8
+        # we can see that LightBlue corresponds to 91 (0x5b) and Salmon to 145 (0x91)
+
+        # I have made the assumption that 0x01 is a null marker and decided to ignore it alltogether.
+        # This assumption might be wrong, hence this message.
+
+        color_table = [
+            "None",
+            "ActiveBorder",
+            "ActiveCaption",
+            "ActiveCaptionText",
+            "AppWorkspace",
+            "Control",
+            "ControlDark",
+            "ControlDarkDark",
+            "ControlLight",
+            "ControlLightLight",
+            "ControlText",
+            "Desktop",
+            "GrayText",
+            "Highlight",
+            "HighlightText",
+            "HotTrack",
+            "InactiveBorder",
+            "InactiveCaption",
+            "InactiveCaptionText",
+            "Info",
+            "InfoText",
+            "Menu",
+            "MenuText",
+            "ScrollBar",
+            "Window",
+            "WindowFrame",
+            "WindowText",
+            "Transparent",
+            "AliceBlue",
+            "AntiqueWhite",
+            "Aqua",
+            "Aquamarine",
+            "Azure",
+            "Beige",
+            "Bisque",
+            "Black",
+            "BlanchedAlmond",
+            "Blue",
+            "BlueViolet",
+            "Brown",
+            "BurlyWood",
+            "CadetBlue",
+            "Chartreuse",
+            "Chocolate",
+            "Coral",
+            "CornflowerBlue",
+            "Cornsilk",
+            "Crimson",
+            "Cyan",
+            "DarkBlue",
+            "DarkCyan",
+            "DarkGoldenrod",
+            "DarkGray",
+            "DarkGreen",
+            "DarkKhaki",
+            "DarkMagenta",
+            "DarkOliveGreen",
+            "DarkOrange",
+            "DarkOrchid",
+            "DarkRed",
+            "DarkSalmon",
+            "DarkSeaGreen",
+            "DarkSlateBlue",
+            "DarkSlateGray",
+            "DarkTurquoise",
+            "DarkViolet",
+            "DeepPink",
+            "DeepSkyBlue",
+            "DimGray",
+            "DodgerBlue",
+            "Firebrick",
+            "FloralWhite",
+            "ForestGreen",
+            "Fuchsia",
+            "Gainsboro",
+            "GhostWhite",
+            "Gold",
+            "Goldenrod",
+            "Gray",
+            "Green",
+            "GreenYellow",
+            "Honeydew",
+            "HotPink",
+            "IndianRed",
+            "Indigo",
+            "Ivory",
+            "Khaki",
+            "Lavender",
+            "LavenderBlush",
+            "LawnGreen",
+            "LemonChiffon",
+            "LightBlue",
+            "LightCoral",
+            "LightCyan",
+            "LightGoldenrodYellow",
+            "LightGray",
+            "LightGreen",
+            "LightPink",
+            "LightSalmon",
+            "LightSeaGreen",
+            "LightSkyBlue",
+            "LightSlateGray",
+            "LightSteelBlue",
+            "LightYellow",
+            "Lime",
+            "LimeGreen",
+            "Linen",
+            "Magenta",
+            "Maroon",
+            "MediumAquamarine",
+            "MediumBlue",
+            "MediumOrchid",
+            "MediumPurple",
+            "MediumSeaGreen",
+            "MediumSlateBlue",
+            "MediumSpringGreen",
+            "MediumTurquoise",
+            "MediumVioletRed",
+            "MidnightBlue",
+            "MintCream",
+            "MistyRose",
+            "Moccasin",
+            "NavajoWhite",
+            "Navy",
+            "OldLace",
+            "Olive",
+            "OliveDrab",
+            "Orange",
+            "OrangeRed",
+            "Orchid",
+            "PaleGoldenrod",
+            "PaleGreen",
+            "PaleTurquoise",
+            "PaleVioletRed",
+            "PapayaWhip",
+            "PeachPuff",
+            "Peru",
+            "Pink",
+            "Plum",
+            "PowderBlue",
+            "Purple",
+            "Red",
+            "RosyBrown",
+            "RoyalBlue",
+            "SaddleBrown",
+            "Salmon",
+            "SandyBrown",
+            "SeaGreen",
+            "SeaShell",
+            "Sienna",
+            "Silver",
+            "SkyBlue",
+            "SlateBlue",
+            "SlateGray",
+            "Snow",
+            "SpringGreen",
+            "SteelBlue",
+            "Tan",
+            "Teal",
+            "Thistle",
+            "Tomato",
+            "Turquoise",
+            "Violet",
+            "Wheat",
+            "White",
+            "WhiteSmoke",
+            "Yellow",
+            "YellowGreen",
+            "ButtonFace",
+            "ButtonHighlight",
+            "ButtonShadow",
+            "GradientActiveCaption",
+            "GradientInactiveCaption",
+            "MenuBar",
+            "MenuHighlight",
+        ]
+
+        try:
+            return 'Color: {}'.format(color_table[b[0]]), b[1:]
+        except IndexError:
+            return 'Color: Unknown', b[1:]
 
 
 class Pair(Parser):

--- a/viewstate/parse.py
+++ b/viewstate/parse.py
@@ -41,15 +41,6 @@ class Const(Parser):
         return cls.const, remain
 
 
-class Noop(Parser):
-    # This class is not up to specification. No value should be added to the parsed tree.
-    marker = 0x01
-
-    @staticmethod
-    def parse(b):
-        return None, b
-
-
 class NoneConst(Const):
     marker = 0x64
     const = None
@@ -310,10 +301,17 @@ class Color(Parser):
             "MenuHighlight",
         ]
 
+        color = 'Unknown'
         try:
-            return 'Color: {}'.format(color_table[b[0]]), b[1:]
+            color = 'Color: {}'.format(color_table[b[0]])
         except IndexError:
-            return 'Color: Unknown', b[1:]
+            pass
+
+        # If color packet ends with `\x01`
+        if len(b) > 1 and b[1] == 1:
+            return color, b[2:]
+        else:
+            return color, b[1:]
 
 
 class Pair(Parser):
@@ -385,10 +383,15 @@ class Array(Parser):
     @staticmethod
     def parse(b):
         n, remain = Integer.parse(b)
+        if n > 400:
+            n, remain = Integer.parse(b)
+
         l = []
         for _ in range(n):
             val, remain = Parser.parse(remain)
             l.append(val)
+        if n>400:
+            print("lel")
         return l, remain
 
 

--- a/viewstate/parse.py
+++ b/viewstate/parse.py
@@ -383,15 +383,10 @@ class Array(Parser):
     @staticmethod
     def parse(b):
         n, remain = Integer.parse(b)
-        if n > 400:
-            n, remain = Integer.parse(b)
-
         l = []
         for _ in range(n):
             val, remain = Parser.parse(remain)
             l.append(val)
-        if n>400:
-            print("lel")
         return l, remain
 
 


### PR DESCRIPTION
I came across some issues with the color parsing and determined that they're sometimes stored in one byte and sometimes in two. I used MSDN's documentation to make a somewhat-working parser.

[Sample file with one-byte encoding](https://gist.githubusercontent.com/TiberiuD/5d80db5f51bf40443294658c00ca6c97/raw/f2a07730a0e4941c6b65adbe2a86f19335f16dc8/gistfile1.txt)